### PR TITLE
Add a new shared input button component

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,7 +7,8 @@ on:
   # Runs on pushes targeting the default branch and PRs
   push:
     paths:
-      - Apollo/**
+      - Apollo.*/**
+      - '.github/workflows/static.yml'
     branches:
       - main
   pull_request:

--- a/Apollo.Components/Code/TypeTab.razor
+++ b/Apollo.Components/Code/TypeTab.razor
@@ -9,13 +9,12 @@
     <MudStack Row="true" AlignItems="AlignItems.Center">
         <MudText Typo="Typo.h6">Discovered Types</MudText>
         <MudSpacer />
-        <MudTextField @bind-Value="_searchText"
-                      Placeholder="Search types and methods..."
-                      Immediate="true"
-                      Variant="Variant.Text"
-                      Margin="Margin.Dense"
-                      AdornmentIcon="@Icons.Material.Filled.Search"
-                      Adornment="Adornment.Start"/>
+        <InputButton @bind-Value="_searchText"
+                     Icon="@Icons.Material.Filled.Search"
+                     Tooltip="Search..."
+                     Placeholder="Search types and methods..."
+                     AdornmentIcon="@Icons.Material.Filled.Search"
+                     Adornment="Adornment.Start"/>
     </MudStack>
     
     <MudDivider />

--- a/Apollo.Components/Shared/InputButton.razor
+++ b/Apollo.Components/Shared/InputButton.razor
@@ -1,0 +1,113 @@
+@using Apollo.Components.Theme
+@inherits Apollo.Components.Infrastructure.ApolloBaseComponent
+
+<MudStack Row="true" AlignItems="AlignItems.Center">
+    @if (_editing)
+    {
+        <MudTextField @ref="_textField"
+                      Value="@_value"
+                      ValueChanged="@ValueChanged"
+                     Label="@Label"
+                     Placeholder="@Placeholder"
+                     Immediate="true"
+                     Variant="@Variant"
+                     Margin="@Margin"
+                     AdornmentIcon="@AdornmentIcon"
+                     Adornment="@Adornment"
+                     OnBlur="@HandleBlur"
+                     OnKeyDown="@HandleKeyDown" />
+                     
+        <ApolloIconButton Icon="@ApolloIcons.Close" 
+                         Size="Size.Small"
+                         Color="Color.Error"
+                         Tooltip="Cancel"
+                         OnClick="@Cancel"/>
+                         
+        <ApolloIconButton Icon="@ApolloIcons.Accept"
+                         Size="Size.Small"
+                         Color="Color.Success"
+                         Tooltip="Save"
+                         OnClick="@Save"/>
+    }
+    else
+    {
+        <ApolloIconButton Icon="@Icon"
+                         Size="@Size"
+                         Color="@Color"
+                         Tooltip="@Tooltip"
+                         OnClick="@StartEditing"/>
+    }
+</MudStack>
+
+@code {
+    private bool _editing = false;
+    private string _value = "";
+    private MudTextField<string> _textField = null!;
+
+    [Parameter] public string Value { get; set; } = "";
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    
+    [Parameter] public string Icon { get; set; } = Icons.Material.Filled.Search;
+    [Parameter] public string Tooltip { get; set; } = "Search";
+    [Parameter] public Size Size { get; set; } = Size.Medium;
+    [Parameter] public Color Color { get; set; } = Color.Default;
+    
+    // TextField parameters
+    [Parameter] public string Label { get; set; } = "";
+    [Parameter] public string Placeholder { get; set; } = "";
+    [Parameter] public Variant Variant { get; set; } = Variant.Text;
+    [Parameter] public Margin Margin { get; set; } = Margin.Dense;
+    [Parameter] public string AdornmentIcon { get; set; } = "";
+    [Parameter] public Adornment Adornment { get; set; } = Adornment.None;
+
+    protected override void OnParametersSet()
+    {
+        _value = Value;
+    }
+
+    private async Task StartEditing()
+    {
+        _editing = true;
+        StateHasChanged();
+        
+        await Task.Delay(50);
+        await _textField.FocusAsync();
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key == "Escape")
+        {
+            await Cancel();
+        }
+        else if (args.Key == "Enter")
+        {
+            await Save();
+        }
+    }
+
+    private async Task HandleBlur()
+    {
+        // Only cancel on blur if we're still editing
+        if (_editing)
+        {
+            await Cancel();
+        }
+    }
+
+    private async Task Save()
+    {
+        if (_value != Value)
+        {
+            await ValueChanged.InvokeAsync(_value);
+        }
+        _editing = false;
+    }
+
+    private async Task Cancel()
+    {
+        _value = Value;
+        _editing = false;
+        await ValueChanged.InvokeAsync(_value);
+    }
+} 

--- a/Apollo.Test/Components/ApolloBaseTestContext.cs
+++ b/Apollo.Test/Components/ApolloBaseTestContext.cs
@@ -1,0 +1,11 @@
+using Bunit;
+
+namespace Apollo.Test.Components;
+
+public abstract class ApolloBaseTestContext : TestContext
+{
+    protected ApolloBaseTestContext()
+    {
+        this.AddDefaultTestServices();
+    }
+} 

--- a/Apollo.Test/Components/Shared/InputButtonTests.cs
+++ b/Apollo.Test/Components/Shared/InputButtonTests.cs
@@ -1,0 +1,153 @@
+using Apollo.Components.Shared;
+using Bunit;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+using MudBlazor.Services;
+using Shouldly;
+using Xunit;
+
+namespace Apollo.Test.Components.Shared;
+
+public class InputButtonTests : ApolloBaseTestContext
+{
+    [Fact]
+    public void Should_Start_In_Button_Mode()
+    {
+        // Arrange & Act
+        var cut = RenderComponent<InputButton>();
+
+        // Assert
+        cut.FindComponent<ApolloIconButton>().ShouldNotBeNull();
+        cut.FindComponents<MudTextField<string>>().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Should_Switch_To_Edit_Mode_When_Clicked()
+    {
+        // Arrange
+        var cut = RenderComponent<InputButton>();
+        
+        // Act
+        cut.FindComponent<ApolloIconButton>().Find("button").Click();
+        
+        // Assert
+        cut.FindComponent<MudTextField<string>>().ShouldNotBeNull();
+        cut.FindComponents<ApolloIconButton>().Count.ShouldBe(2); // Save and Cancel buttons
+    }
+
+    [Fact]
+    public async Task Should_Update_Value_On_Save()
+    {
+        // Arrange
+        var currentValue = "";
+        var cut = RenderComponent<InputButton>(parameters => parameters
+            .Add(p => p.Value, currentValue)
+            .Add(p => p.ValueChanged, (string v) => currentValue = v)
+        );
+        
+        // Act
+        cut.FindComponent<ApolloIconButton>().Find("button").Click();
+        var textField = cut.FindComponent<MudTextField<string>>();
+        await textField.InvokeAsync(() => textField.Instance.ValueChanged.InvokeAsync("test value"));
+        
+        var saveButton = cut.FindComponents<ApolloIconButton>()
+            .First(b => b.Instance.Tooltip == "Save");
+        await saveButton.InvokeAsync(() => saveButton.Instance.OnClick.InvokeAsync());
+
+        // Assert
+        currentValue.ShouldBe("test value");
+        cut.FindComponents<MudTextField<string>>().Count.ShouldBe(0); // Back to button mode
+    }
+
+    [Fact]
+    public async Task Should_Not_Update_Value_On_Cancel()
+    {
+        // Arrange
+        var currentValue = "original";
+        var cut = RenderComponent<InputButton>(parameters => parameters
+            .Add(p => p.Value, currentValue)
+            .Add(p => p.ValueChanged, (string v) => currentValue = v)
+        );
+        
+        // Act
+        cut.FindComponent<ApolloIconButton>().Find("button").Click();
+        var textField = cut.FindComponent<MudTextField<string>>();
+        await textField.InvokeAsync(() => textField.Instance.ValueChanged.InvokeAsync("test value"));
+        
+        var cancelButton = cut.FindComponents<ApolloIconButton>()
+            .First(b => b.Instance.Tooltip == "Cancel");
+        await cancelButton.InvokeAsync(() => cancelButton.Instance.OnClick.InvokeAsync());
+
+        // Assert
+        currentValue.ShouldBe("original");
+        cut.FindComponents<MudTextField<string>>().Count.ShouldBe(0); // Back to button mode
+    }
+
+    [Fact]
+    public async Task Should_Handle_Enter_Key_As_Save()
+    {
+        // Arrange
+        var currentValue = "";
+        var cut = RenderComponent<InputButton>(parameters => parameters
+            .Add(p => p.Value, currentValue)
+            .Add(p => p.ValueChanged, (string v) => currentValue = v)
+        );
+        
+        // Act
+        cut.FindComponent<ApolloIconButton>().Find("button").Click();
+        var textField = cut.FindComponent<MudTextField<string>>();
+        await textField.InvokeAsync(() => textField.Instance.ValueChanged.InvokeAsync("test value"));
+        
+        await textField.InvokeAsync(() => textField.Instance.OnKeyDown.InvokeAsync(
+            new KeyboardEventArgs { Key = "Enter" }));
+
+        // Assert
+        currentValue.ShouldBe("test value");
+        cut.FindComponents<MudTextField<string>>().Count.ShouldBe(0); // Back to button mode
+    }
+
+    [Fact]
+    public async Task Should_Handle_Escape_Key_As_Cancel()
+    {
+        // Arrange
+        var currentValue = "original";
+        var cut = RenderComponent<InputButton>(parameters => parameters
+            .Add(p => p.Value, currentValue)
+            .Add(p => p.ValueChanged, (string v) => currentValue = v)
+        );
+        
+        // Act
+        cut.FindComponent<ApolloIconButton>().Find("button").Click();
+        var textField = cut.FindComponent<MudTextField<string>>();
+        await textField.InvokeAsync(() => textField.Instance.ValueChanged.InvokeAsync("test value"));
+        
+        await textField.InvokeAsync(() => textField.Instance.OnKeyDown.InvokeAsync(
+            new KeyboardEventArgs { Key = "Escape" }));
+
+        // Assert
+        currentValue.ShouldBe("original");
+        cut.FindComponents<MudTextField<string>>().Count.ShouldBe(0); // Back to button mode
+    }
+
+    [Fact]
+    public async Task Should_Cancel_On_Blur()
+    {
+        // Arrange
+        var currentValue = "original";
+        var cut = RenderComponent<InputButton>(parameters => parameters
+            .Add(p => p.Value, currentValue)
+            .Add(p => p.ValueChanged, (string v) => currentValue = v)
+        );
+        
+        // Act
+        cut.FindComponent<ApolloIconButton>().Find("button").Click();
+        var textField = cut.FindComponent<MudTextField<string>>();
+        await textField.InvokeAsync(() => textField.Instance.ValueChanged.InvokeAsync("test value"));
+        
+        await textField.InvokeAsync(() => textField.Instance.OnBlur.InvokeAsync());
+
+        // Assert
+        currentValue.ShouldBe("original");
+        cut.FindComponents<MudTextField<string>>().Count.ShouldBe(0); // Back to button mode
+    }
+}

--- a/Apollo.Test/Components/TestSetupExtensions.cs
+++ b/Apollo.Test/Components/TestSetupExtensions.cs
@@ -1,0 +1,19 @@
+using Bunit;
+using MudBlazor.Services;
+
+namespace Apollo.Test.Components;
+
+public static class TestSetupExtensions
+{
+    public static void AddDefaultTestServices(this TestContext ctx)
+    {
+        ctx.Services.AddMudServices(options =>
+        {
+            options.SnackbarConfiguration.ShowTransitionDuration = 0;
+            options.SnackbarConfiguration.HideTransitionDuration = 0;
+            options.PopoverOptions.CheckForPopoverProvider = false;
+        });
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.JSInterop.SetupVoid("mudPopover.initialize", _ => true);
+    }
+}


### PR DESCRIPTION
 - Helps keep UI simple
 - Supports tooltip for icon
 - Pop out input field with auto focus
 - Supports cancel/save for clearing
 - Two-way bindable